### PR TITLE
chore: bump Istio version to 1.25.5 to fix schema validation issue

### DIFF
--- a/charts/k0rdent-istio-base/values.yaml
+++ b/charts/k0rdent-istio-base/values.yaml
@@ -22,7 +22,7 @@ global: {}
 injectionNamespaces: []
 
 gateway:
-  version: 1.24.3
+  version: 1.25.5
 
   resource:
     apiVersion: networking.istio.io/v1

--- a/charts/k0rdent-istio/Chart.lock
+++ b/charts/k0rdent-istio/Chart.lock
@@ -4,9 +4,9 @@ dependencies:
   version: v0.14.0
 - name: base
   repository: https://istio-release.storage.googleapis.com/charts
-  version: 1.24.3
+  version: 1.25.5
 - name: istiod
   repository: https://istio-release.storage.googleapis.com/charts
-  version: 1.24.3
-digest: sha256:57e8d8db8b9773f8c1cff256cda10742f63f8e96183a95462f5a653ea83f3279
-generated: "2025-10-01T17:01:39.645551+03:00"
+  version: 1.25.5
+digest: sha256:261dc929a1591dc2b82db3df80a89894cefba4d7105fe173cd0661fe5e337592
+generated: "2025-10-15T09:54:28.583709+03:00"

--- a/charts/k0rdent-istio/Chart.yaml
+++ b/charts/k0rdent-istio/Chart.yaml
@@ -9,8 +9,8 @@ dependencies:
     repository: "https://charts.jetstack.io"
   - alias: istiobase
     name: base
-    version: "1.24.3"
+    version: "1.25.5"
     repository: "https://istio-release.storage.googleapis.com/charts"
   - name: istiod
-    version: "1.24.3"
+    version: "1.25.5"
     repository: "https://istio-release.storage.googleapis.com/charts"

--- a/charts/k0rdent-istio/values.yaml
+++ b/charts/k0rdent-istio/values.yaml
@@ -2,7 +2,7 @@ cert-manager:
   enabled: true
   template: cert-manager-v1-16-4
 gateway:
-  version: 1.24.3
+  version: 1.25.5
 kcm:
   namespace: kcm-system
 telemetry:


### PR DESCRIPTION
* This PR fixes a schema validation issue with the Istio gateway chart, which failed to install on remote clusters after the [KCM commit](https://github.com/k0rdent/kcm/commit/943e59f30978fd41644ee7fb2638aba8cdfeaad2). That commit updated projectsveltos to version 1.1.1, which installs Helm charts on remote clusters using Helm 3.19.
* According to this [Istio issue](https://github.com/istio/istio/issues/57354), schema validation problems with Istio gateway charts started appearing after Helm 3.18.5.
* To resolve this, the Istio chart version was bumped from 1.24.3 to 1.25.5.