### PR TITLE
fix: downgrade istiod and istio-base charts to restore kube-api access on injected pods

### DIFF
--- a/charts/k0rdent-istio/Chart.lock
+++ b/charts/k0rdent-istio/Chart.lock
@@ -4,9 +4,9 @@ dependencies:
   version: v0.14.0
 - name: base
   repository: https://istio-release.storage.googleapis.com/charts
-  version: 1.25.5
+  version: 1.25.3
 - name: istiod
   repository: https://istio-release.storage.googleapis.com/charts
-  version: 1.25.5
-digest: sha256:261dc929a1591dc2b82db3df80a89894cefba4d7105fe173cd0661fe5e337592
-generated: "2025-10-15T09:54:28.583709+03:00"
+  version: 1.25.3
+digest: sha256:9a0828640e706cd12d0016933405b1e428c1f62539b37ef2fdf8056e94002b88
+generated: "2025-10-25T13:43:14.007184+03:00"

--- a/charts/k0rdent-istio/Chart.yaml
+++ b/charts/k0rdent-istio/Chart.yaml
@@ -9,8 +9,8 @@ dependencies:
     repository: "https://charts.jetstack.io"
   - alias: istiobase
     name: base
-    version: "1.25.5"
+    version: "1.25.3"
     repository: "https://istio-release.storage.googleapis.com/charts"
   - name: istiod
-    version: "1.25.5"
+    version: "1.25.3"
     repository: "https://istio-release.storage.googleapis.com/charts"


### PR DESCRIPTION
- **Problem**: After commit #6, pods on remote clusters that have Istio injection lose the ability to connect to the Kubernetes API, causing pod restarts and crashes.
- **Investigation**:
   - On the management and adopted clusters, everything works fine.
   - The issue was traced to Istio version 1.25.4 and above.
   - After debugging, no solution was found.
- **Workaround**:
   - Downgrade `istiod` to version 1.25.3 to restore Kubernetes API connectivity for injected pods.
   - Keep the `istio-gateway` chart on version 1.25.5 to retain the fix introduced in commit #6.