### PR TITLE
chore: remove creation of external namespace with injection label

### DIFF
--- a/charts/k0rdent-istio/templates/k0rdent/istio/mcs.yaml
+++ b/charts/k0rdent-istio/templates/k0rdent/istio/mcs.yaml
@@ -15,7 +15,7 @@ spec:
       k0rdent.mirantis.com/istio-role: member
   dependsOn:
     - {{ .Chart.Name }}-cert-manager
-    - {{ .Chart.Name }}-namespaces
+    - {{ .Chart.Name }}-namespace
   serviceSpec:
     services:
       - name: k0rdent-istio

--- a/charts/k0rdent-istio/templates/namespace/cm-template.yaml
+++ b/charts/k0rdent-istio/templates/namespace/cm-template.yaml
@@ -2,7 +2,7 @@
 apiVersion: v1
 kind: ConfigMap
 metadata:
-  name: {{ .Chart.Name }}-namespaces-template
+  name: {{ .Chart.Name }}-namespace-template
   namespace: {{ .Values.kcm.namespace }}
   annotations:
     projectsveltos.io/template: "true"
@@ -17,13 +17,4 @@ data:
         helm.sh/resource-policy: keep
       labels:
         topology.istio.io/network: {{ `{{ .Cluster.metadata.name }}` }}-network
-    {{- range .Values.injectionNamespaces }}
-    ---
-    kind: Namespace
-    apiVersion: v1
-    metadata:
-      name: {{ . }}
-      labels:
-        istio-injection: enabled
-    {{- end }}
 {{- end }}

--- a/charts/k0rdent-istio/templates/namespace/mcs.yaml
+++ b/charts/k0rdent-istio/templates/namespace/mcs.yaml
@@ -2,22 +2,22 @@
 apiVersion: k0rdent.mirantis.com/v1beta1
 kind: MultiClusterService
 metadata:
-  name: {{ .Chart.Name }}-namespaces
+  name: {{ .Chart.Name }}-namespace
 spec:
   clusterSelector:
     matchLabels:
       k0rdent.mirantis.com/istio-role: member
   serviceSpec:
     services:
-      - name: {{ .Chart.Name }}-namespaces
+      - name: {{ .Chart.Name }}-namespace
         namespace: {{ .Values.kcm.namespace }}
-        template: {{ .Chart.Name }}-namespaces
+        template: {{ .Chart.Name }}-namespace
 ---
-# This MCS needed as a workaround to propagate namespaces to KCM Region clusters
+# This MCS needed as a workaround to propagate istio namespace to KCM Region clusters
 apiVersion: k0rdent.mirantis.com/v1beta1
 kind: MultiClusterService
 metadata:
-  name: {{ .Chart.Name }}-namespaces-template-propagation
+  name: {{ .Chart.Name }}-namespace-template-propagation
 spec:
   clusterSelector:
     matchLabels:
@@ -32,6 +32,6 @@ spec:
         resource:
           apiVersion: v1
           kind: ConfigMap
-          name: {{ .Chart.Name }}-namespaces-template
+          name: {{ .Chart.Name }}-namespace-template
           namespace: {{ .Values.kcm.namespace }}
 {{- end }}

--- a/charts/k0rdent-istio/templates/namespace/svctmpl.yaml
+++ b/charts/k0rdent-istio/templates/namespace/svctmpl.yaml
@@ -2,7 +2,7 @@
 apiVersion: k0rdent.mirantis.com/v1beta1
 kind: ServiceTemplate
 metadata:
-  name: {{ .Chart.Name }}-namespaces
+  name: {{ .Chart.Name }}-namespace
   namespace: {{ .Values.kcm.namespace }}
   annotations:
     helm.sh/resource-policy: keep
@@ -10,7 +10,7 @@ spec:
   resources:
     localSourceRef:
       kind: ConfigMap
-      name: {{ .Chart.Name }}-namespaces-template
+      name: {{ .Chart.Name }}-namespace-template
       namespace: {{ .Values.kcm.namespace }}
     deploymentType: Remote
     path: ""

--- a/charts/k0rdent-istio/values.yaml
+++ b/charts/k0rdent-istio/values.yaml
@@ -178,9 +178,6 @@ k0rdent-istio:
       type: oci
       url: oci://ghcr.io/k0rdent/istio/charts
 
-# -- List of namespaces on remote clusters where Istio sidecar injection should be enabled
-injectionNamespaces: []
-
 # -- Config of `ServiceTemplate` to use `cert-manager` in `MultiClusterService`.
 cert-manager-service-template:
   enabled: true


### PR DESCRIPTION
Closes #20 

This commit removes the creation of an external namespace marked with an injection label, preventing the namespace from being deleted during Istio uninstallation.