### PR TITLE
fix: .repo.spec required by kgst 2.0.1, correct cert-manager:v1.19.3 with v

### DIFF
--- a/charts/k0rdent-istio/templates/cert/mcs.yaml
+++ b/charts/k0rdent-istio/templates/cert/mcs.yaml
@@ -18,44 +18,43 @@ spec:
         namespace: {{ .Release.Namespace }}
         template: {{ index .Values "cert-manager" "template" }}
         values: |
-          cert-manager:
-            crds:
-              enabled: true
-            {{- with $customRegistry }}
+          crds:
+            enabled: true
+          {{- with $customRegistry }}
+          image:
+            repository: {{ . }}/jetstack/cert-manager-controller
+          acmesolver:
             image:
-              repository: {{ . }}/jetstack/cert-manager-controller
-            acmesolver:
-              image:
-                repository: {{ . }}/jetstack/cert-manager-acmesolver
-            cainjector:
-              image:
-                repository: {{ . }}/jetstack/cert-manager-cainjector
-            startupapicheck:
-              image:
-                repository: {{ . }}/jetstack/cert-manager-startupapicheck
-            webhook:
-              image:
-                repository: {{ . }}/jetstack/cert-manager-webhook
-            {{- end }}
+              repository: {{ . }}/jetstack/cert-manager-acmesolver
+          cainjector:
+            image:
+              repository: {{ . }}/jetstack/cert-manager-cainjector
+          startupapicheck:
+            image:
+              repository: {{ . }}/jetstack/cert-manager-startupapicheck
+          webhook:
+            image:
+              repository: {{ . }}/jetstack/cert-manager-webhook
+          {{- end }}
 ---
-{{- if lookup "k0rdent.mirantis.com/v1beta1" "ServiceTemplate" .Values.kcm.namespace "cert-manager-1-19-3" }}
+{{- if lookup "k0rdent.mirantis.com/v1beta1" "ServiceTemplate" .Values.kcm.namespace "cert-manager-v1-19-3" }}
 {{- if lookup "k0rdent.mirantis.com/v1beta1" "ServiceTemplate" .Values.kcm.namespace "cert-manager-v1-16-4" }}
 ---
 apiVersion: k0rdent.mirantis.com/v1beta1
 kind: ServiceTemplateChain
 metadata:
-  name: cert-manager-1-19-3-from-v1-16-4
+  name: cert-manager-v1-19-3-from-v1-16-4
   namespace: {{ $.Values.kcm.namespace }}
   annotations:
     helm.sh/resource-policy: keep
     helm.sh/hook: post-install, post-upgrade
 spec:
   supportedTemplates:
-    - name: cert-manager-1-19-3
+    - name: cert-manager-v1-19-3
     - name: cert-manager-v1-16-4
       availableUpgrades:
-        - name: cert-manager-1-19-3
-          version: 1.19.3
+        - name: cert-manager-v1-19-3
+          version: v1.19.3
 {{- end }}
 {{- end }}
 {{- end }}

--- a/charts/k0rdent-istio/values.yaml
+++ b/charts/k0rdent-istio/values.yaml
@@ -6,7 +6,7 @@ kcm:
 isManagement: true
 
 cert-manager:
-  # -- Whether cert-manager is present in the cluster
+  # -- ServiceTemplate name
   template: cert-manager-v1-19-3
 
 global:
@@ -191,8 +191,9 @@ k0rdent-istio:
 # -- Config of `ServiceTemplate` to use `cert-manager` in `MultiClusterService`.
 cert-manager-service-template:
   enabled: true
+  name: cert-manager
   repo:
-    name: cert-manager
-    url: https://charts.jetstack.io
+    spec:
+      url: oci://quay.io/jetstack/charts
   chart: cert-manager:v1.19.3
   namespace: kcm-system

--- a/charts/k0rdent-istio/values.yaml
+++ b/charts/k0rdent-istio/values.yaml
@@ -7,7 +7,7 @@ isManagement: true
 
 cert-manager:
   # -- Whether cert-manager is present in the cluster
-  template: cert-manager-1-19-3
+  template: cert-manager-v1-19-3
 
 global:
   # -- Address of the Istio CSR service provided by cert-manager
@@ -194,5 +194,5 @@ cert-manager-service-template:
   repo:
     name: cert-manager
     url: https://charts.jetstack.io
-  chart: cert-manager:1.19.3
+  chart: cert-manager:v1.19.3
   namespace: kcm-system


### PR DESCRIPTION
* Similar to https://github.com/k0rdent/kof/pull/901