### PR TITLE
fix: prevent ServiceTemplateChain immutability error on repeated upgrades

### DIFF
--- a/charts/k0rdent-istio/templates/k0rdent/istio/mcs.yaml
+++ b/charts/k0rdent-istio/templates/k0rdent/istio/mcs.yaml
@@ -19,7 +19,7 @@ spec:
     services:
       - name: k0rdent-istio
         namespace: {{ .Release.Namespace }}
-        template: {{ .Chart.Name }}-{{ $version }}
+        template: {{ .Chart.Name }}-main-{{ $version }}
         values: |
           operator:
             enabled: false

--- a/charts/k0rdent-istio/templates/k0rdent/istio/svctmpl.yaml
+++ b/charts/k0rdent-istio/templates/k0rdent/istio/svctmpl.yaml
@@ -1,6 +1,7 @@
 {{- if .Values.isManagement }}
 {{- $chartVersion := .Chart.Version | replace "." "-" }}
-{{- $templates := list
+{{- /*
+TODO: Add back the main template to the list after the new release
   (dict
     "name" (printf "%s-%s" .Chart.Name $chartVersion)
     "prefix" (printf "%s-" .Chart.Name)
@@ -9,6 +10,8 @@
     "version" .Chart.Version
     "repo" (index .Values "k0rdent-istio" "repo" "name")
   )
+*/ -}}
+{{- $templates := list
   (dict
     "name" (printf "%s-gateway-%s" .Chart.Name $chartVersion)
     "prefix" (printf "%s-gateway-" .Chart.Name)
@@ -82,4 +85,38 @@ spec:
       {{- end }}
     {{- end }}
 {{- end }}
+---
+# TODO: Delete this ServiceTemplate after the new release
+apiVersion: k0rdent.mirantis.com/v1beta1
+kind: ServiceTemplate
+metadata:
+  name: {{ .Chart.Name }}-main-{{ $chartVersion }}
+  namespace: {{ .Values.kcm.namespace }}
+  annotations:
+    helm.sh/resource-policy: keep
+spec:
+  helm:
+    chartSpec:
+      chart: {{ .Chart.Name }}
+      version: {{ .Chart.Version | quote }}
+      interval: 10m0s
+      sourceRef:
+        kind: HelmRepository
+        name: {{ index .Values "k0rdent-istio" "repo" "name" }}
+---
+# TODO: Delete this ServiceTemplateChain after the new release
+apiVersion: k0rdent.mirantis.com/v1beta1
+kind: ServiceTemplateChain
+metadata:
+  name: {{ .Chart.Name }}-main-{{ $chartVersion }}
+  namespace: {{ .Values.kcm.namespace }}
+  annotations:
+    helm.sh/resource-policy: keep
+spec:
+  supportedTemplates:
+    - name: {{ .Chart.Name }}-main-{{ $chartVersion }}
+    - name: {{ .Chart.Name }}-0-5-0
+      availableUpgrades:
+        - name: {{ .Chart.Name }}-main-{{ $chartVersion }}
+          version: {{ .Chart.Version | quote }}
 {{- end }}

--- a/charts/k0rdent-istio/templates/k0rdent/istio/svctmpl.yaml
+++ b/charts/k0rdent-istio/templates/k0rdent/istio/svctmpl.yaml
@@ -3,8 +3,8 @@
 {{- /*
 TODO: Add back the main template to the list after the new release
   (dict
-    "name" (printf "%s-%s" .Chart.Name $chartVersion)
-    "prefix" (printf "%s-" .Chart.Name)
+    "name" (printf "%s-main-%s" .Chart.Name $chartVersion)
+    "prefix" (printf "%s-main" .Chart.Name)
     "specType" "helm"
     "chart" .Chart.Name
     "version" .Chart.Version


### PR DESCRIPTION
This PR fix immutability error in ServiceTemplateChain during upgrades.

**Issue:**
1. On the first install, lookup returns no results because the objects do not exist yet, so the main chain is stored as `[k0rdent-istio-0-5-0]`.
2. On subsequent upgrade/reinstall, lookup returns all previously created sibling ServiceTemplate objects. Because the chart prefix (k0rdent-istio-) also matches sibling resources (e.g. `k0rdent-istio-gateway-*`, `k0rdent-istio-` `propagation-*`, `k0rdent-istio-namespace-*`), these were incorrectly included in the main chain's supportedTemplates.

This results in a spec mismatch with the originally stored (immutable) resource, causing the patch operation to fail.