### PR TITLE
feat: update MCS when Istio release version label changes

### DIFF
--- a/charts/k0rdent-istio/templates/operator/operator-deployment.yaml
+++ b/charts/k0rdent-istio/templates/operator/operator-deployment.yaml
@@ -59,7 +59,7 @@ spec:
             value: {{ .Release.Namespace }}
           - name: "RELEASE_NAME"
             value: {{ .Chart.Name }}
-          - name: "ISTIO_TEMPLATE_VERSION_SUFFIX"
+          - name: "RELEASE_VERSION"
             value: {{ .Chart.Version | replace "." "-" | quote }}
         image: "
           {{- if and $global.registry (ne $global.registry "docker.io") }}{{ $global.registry }}

--- a/istio-operator/cmd/main.go
+++ b/istio-operator/cmd/main.go
@@ -75,10 +75,10 @@ func main() {
 		"Namespace where Istio is installed. Default is 'istio-system'.")
 	flag.StringVar(&istio.IstioReleaseName, "istio-release-name", "k0rdent-istio", "Name of the Istio release.")
 	flag.StringVar(
-		&istio.IstioTemplateVersionSuffix,
-		"istio-template-version-suffix",
-		os.Getenv("ISTIO_TEMPLATE_VERSION_SUFFIX"),
-		"Optional suffix for service template names (for example: 0-4-2).",
+		&istio.ReleaseVersion,
+		"release-version",
+		os.Getenv("RELEASE_VERSION"),
+		"K0rdent Istio release version (for example: 0-4-2).",
 	)
 	flag.StringVar(&metricsAddr, "metrics-bind-address", "0", "The address the metrics endpoint binds to. "+
 		"Use :8443 for HTTPS or :8080 for HTTP, or leave as 0 to disable the metrics service.")

--- a/istio-operator/internal/controller/clusterdeployment_controller.go
+++ b/istio-operator/internal/controller/clusterdeployment_controller.go
@@ -28,6 +28,7 @@ import (
 	"github.com/k0rdent/istio/istio-operator/internal/controller/istio/multicluster"
 	remotesecret "github.com/k0rdent/istio/istio-operator/internal/controller/istio/remote-secret"
 	"github.com/k0rdent/istio/istio-operator/internal/controller/utils"
+	label "github.com/k0rdent/istio/istio-operator/internal/labels"
 	"k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/runtime"
 	"k8s.io/apimachinery/pkg/types"
@@ -89,7 +90,7 @@ func (r *ClusterDeploymentReconciler) SetupWithManager(mgr ctrl.Manager) error {
 		For(&kcmv1beta1.ClusterDeployment{}).
 		WithEventFilter(predicate.NewPredicateFuncs(func(obj client.Object) bool {
 			labels := obj.GetLabels()
-			return slices.Contains(istio.IstioRoleLabelExpectedValues, labels[istio.IstioRoleLabel])
+			return slices.Contains(istio.IstioRoleLabelExpectedValues, labels[label.IstioRoleLabel])
 		})).
 		WithOptions(controller.Options{
 			RateLimiter: workqueue.NewTypedItemExponentialFailureRateLimiter[reconcile.Request](
@@ -134,7 +135,7 @@ func (r *ClusterDeploymentReconciler) tryDeleteResources(ctx context.Context, re
 			"Failed to delete MultiClusterService",
 			clusterDeployment,
 			err,
-			"multiClusterServiceName", multicluster.GetMultiClusterServiceNameHash(req.Name, req.Namespace),
+			"multiClusterServiceName", multicluster.MultiClusterServiceName(req.Name, req.Namespace),
 		)
 		return ctrl.Result{}, err
 	}
@@ -174,7 +175,7 @@ func (r *ClusterDeploymentReconciler) tryCreateResources(ctx context.Context, re
 			"Failed to create MultiClusterService",
 			clusterDeployment,
 			err,
-			"multiClusterServiceName", multicluster.GetMultiClusterServiceNameHash(req.Name, req.Namespace),
+			"multiClusterServiceName", multicluster.MultiClusterServiceName(req.Name, req.Namespace),
 		)
 		return ctrl.Result{}, err
 	}

--- a/istio-operator/internal/controller/clusterdeployment_controller_test.go
+++ b/istio-operator/internal/controller/clusterdeployment_controller_test.go
@@ -12,6 +12,7 @@ import (
 	"github.com/k0rdent/istio/istio-operator/internal/controller/istio/multicluster"
 	remotesecret "github.com/k0rdent/istio/istio-operator/internal/controller/istio/remote-secret"
 	"github.com/k0rdent/istio/istio-operator/internal/k8s"
+	"github.com/k0rdent/istio/istio-operator/internal/labels"
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
 	corev1 "k8s.io/api/core/v1"
@@ -49,7 +50,7 @@ var _ = Describe("ClusterDeployment Controller", func() {
 		}
 
 		clusterDeploymentLabels := map[string]string{
-			istio.IstioRoleLabel: "member",
+			labels.IstioRoleLabel: labels.IstioRoleLabelMemberValue,
 		}
 
 		clusterDeploymentAnnotations := map[string]string{}

--- a/istio-operator/internal/controller/istio/cert/cert_manager.go
+++ b/istio-operator/internal/controller/istio/cert/cert_manager.go
@@ -12,6 +12,7 @@ import (
 	"github.com/k0rdent/istio/istio-operator/internal/controller/record"
 	"github.com/k0rdent/istio/istio-operator/internal/controller/utils"
 	"github.com/k0rdent/istio/istio-operator/internal/hash"
+	"github.com/k0rdent/istio/istio-operator/internal/labels"
 	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
@@ -40,7 +41,7 @@ func (cm *CertManager) TryCreate(ctx context.Context, clusterDeployment *kcmv1be
 
 	cert := cm.generateClusterCACertificate(clusterDeployment)
 	if err := cm.createCertificate(ctx, cert, clusterDeployment); err != nil {
-		return fmt.Errorf("failed to create istio certificate: %v", err)
+		return fmt.Errorf("failed to create istio certificate: %w", err)
 	}
 
 	return nil
@@ -65,7 +66,7 @@ func (cm *CertManager) TryDelete(ctx context.Context, req ctrl.Request) error {
 			log.Info("Istio Certificate already deleted", "certificateName", certName)
 			return nil
 		}
-		return fmt.Errorf("failed to delete istio certificate: %v", err)
+		return fmt.Errorf("failed to delete istio certificate: %w", err)
 	}
 
 	log.Info("Istio Certificate successfully deleted", "certificateName", certName)
@@ -97,7 +98,8 @@ func (cm *CertManager) generateClusterCACertificate(cd *kcmv1beta1.ClusterDeploy
 			Name:      certName,
 			Namespace: istio.IstioSystemNamespace,
 			Labels: map[string]string{
-				"app.kubernetes.io/managed-by": "istio-operator",
+				labels.ManagedByLabel:    labels.ManagedByIstioOperator,
+				labels.IstioVersionLabel: istio.ReleaseVersion,
 			},
 		},
 		Spec: cmv1.CertificateSpec{

--- a/istio-operator/internal/controller/istio/cert/cert_manager.go
+++ b/istio-operator/internal/controller/istio/cert/cert_manager.go
@@ -98,8 +98,8 @@ func (cm *CertManager) generateClusterCACertificate(cd *kcmv1beta1.ClusterDeploy
 			Name:      certName,
 			Namespace: istio.IstioSystemNamespace,
 			Labels: map[string]string{
-				labels.ManagedByLabel:    labels.ManagedByIstioOperator,
-				labels.IstioVersionLabel: istio.ReleaseVersion,
+				labels.ManagedByLabel:           labels.ManagedByIstioOperator,
+				labels.K0rdentIstioVersionLabel: istio.ReleaseVersion,
 			},
 		},
 		Spec: cmv1.CertificateSpec{

--- a/istio-operator/internal/controller/istio/istio.go
+++ b/istio-operator/internal/controller/istio/istio.go
@@ -1,13 +1,16 @@
 package istio
 
-import "fmt"
+import (
+	"fmt"
 
-const (
-	IstioRoleLabel = "k0rdent.mirantis.com/istio-role"
+	"github.com/k0rdent/istio/istio-operator/internal/labels"
 )
 
 // `child` is deprecated but still supported
-var IstioRoleLabelExpectedValues = []string{"member", "child"}
+var IstioRoleLabelExpectedValues = []string{
+	labels.IstioRoleLabelMemberValue,
+	labels.IstioRoleLabelChildValue,
+}
 
 // By default "istio-system"
 var IstioSystemNamespace string
@@ -15,14 +18,12 @@ var IstioSystemNamespace string
 // By default "k0rdent-istio"
 var IstioReleaseName string
 
-// By default ""; when set, service templates are referenced as
-// <release-name>-<template>-<suffix>.
-var IstioTemplateVersionSuffix string
+// By default is empty string, but can be set by the `release-version` flag or the `RELEASE_VERSION` environment variable.
+var ReleaseVersion string
 
 func ServiceTemplateName(template string) string {
-	if IstioTemplateVersionSuffix == "" {
+	if ReleaseVersion == "" {
 		return fmt.Sprintf("%s-%s", IstioReleaseName, template)
 	}
-
-	return fmt.Sprintf("%s-%s-%s", IstioReleaseName, template, IstioTemplateVersionSuffix)
+	return fmt.Sprintf("%s-%s-%s", IstioReleaseName, template, ReleaseVersion)
 }

--- a/istio-operator/internal/controller/istio/multicluster/remote_secret_propagation_manager.go
+++ b/istio-operator/internal/controller/istio/multicluster/remote_secret_propagation_manager.go
@@ -141,10 +141,10 @@ func (m *RemoteSecretPropagationManager) generateMultiClusterService(cd *kcmv1be
 		ObjectMeta: metav1.ObjectMeta{
 			Name: MultiClusterServiceName(cd.Name, cd.Namespace),
 			Labels: map[string]string{
-				labels.ClusterNameLabel:      cd.Name,
-				labels.ClusterNamespaceLabel: cd.Namespace,
-				labels.IstioVersionLabel:     istio.ReleaseVersion,
-				labels.ManagedByLabel:        labels.ManagedByIstioOperator,
+				labels.ClusterNameLabel:         cd.Name,
+				labels.ClusterNamespaceLabel:    cd.Namespace,
+				labels.K0rdentIstioVersionLabel: istio.ReleaseVersion,
+				labels.ManagedByLabel:           labels.ManagedByIstioOperator,
 			},
 		},
 		Spec: kcmv1beta1.MultiClusterServiceSpec{

--- a/istio-operator/internal/controller/istio/multicluster/remote_secret_propagation_manager.go
+++ b/istio-operator/internal/controller/istio/multicluster/remote_secret_propagation_manager.go
@@ -11,6 +11,7 @@ import (
 	"github.com/k0rdent/istio/istio-operator/internal/controller/record"
 	"github.com/k0rdent/istio/istio-operator/internal/controller/utils"
 	"github.com/k0rdent/istio/istio-operator/internal/hash"
+	"github.com/k0rdent/istio/istio-operator/internal/labels"
 	addoncontrollerv1beta1 "github.com/projectsveltos/addon-controller/api/v1beta1"
 	corev1 "k8s.io/api/core/v1"
 	"k8s.io/apimachinery/pkg/api/errors"
@@ -38,19 +39,24 @@ func (m *RemoteSecretPropagationManager) TryCreate(ctx context.Context, clusterD
 		log.Error(err, "Failed to delete deprecated MultiClusterService for secret propagation")
 	}
 
-	exists, err := m.multiClusterServiceExists(ctx, clusterDeployment)
+	mcs, err := m.getMultiClusterService(ctx, clusterDeployment.Name, clusterDeployment.Namespace)
 	if err != nil {
-		return fmt.Errorf("failed to check MultiClusterService existence: %v", err)
+		return fmt.Errorf("failed to get MultiClusterService: %w", err)
 	}
 
-	if exists {
-		log.Info("MultiClusterService already exists")
+	if mcs != nil {
+		log.Info("Trying to update MultiClusterService for secret propagation")
+
+		if err := m.updateMultiClusterService(ctx, clusterDeployment, mcs); err != nil {
+			return fmt.Errorf("failed to update MultiClusterService: %w", err)
+		}
+
 		return nil
 	}
 
 	log.Info("Trying to create MultiClusterService for secret propagation")
 	if err := m.createMultiClusterService(ctx, clusterDeployment); err != nil {
-		return fmt.Errorf("failed to create MultiClusterService resource: %v", err)
+		return fmt.Errorf("failed to create MultiClusterService resource: %w", err)
 	}
 
 	m.sendCreationEvent(clusterDeployment)
@@ -67,7 +73,7 @@ func (m *RemoteSecretPropagationManager) TryDelete(ctx context.Context, req ctrl
 
 	mcs := &kcmv1beta1.MultiClusterService{
 		ObjectMeta: metav1.ObjectMeta{
-			Name: GetMultiClusterServiceNameHash(req.Name, req.Namespace),
+			Name: MultiClusterServiceName(req.Name, req.Namespace),
 		},
 	}
 
@@ -77,7 +83,7 @@ func (m *RemoteSecretPropagationManager) TryDelete(ctx context.Context, req ctrl
 			log.Info("MultiClusterService already deleted")
 			return nil
 		}
-		return fmt.Errorf("failed to delete MultiClusterService: %v", err)
+		return fmt.Errorf("failed to delete MultiClusterService: %w", err)
 	}
 
 	m.sendDeletionEvent(req)
@@ -86,17 +92,42 @@ func (m *RemoteSecretPropagationManager) TryDelete(ctx context.Context, req ctrl
 	return nil
 }
 
-func (m *RemoteSecretPropagationManager) multiClusterServiceExists(ctx context.Context, cd *kcmv1beta1.ClusterDeployment) (bool, error) {
-	return utils.IsResourceExists(
-		ctx,
-		m.client,
-		&kcmv1beta1.MultiClusterService{},
-		GetMultiClusterServiceNameHash(cd.Name, cd.Namespace),
-		"",
-	)
+func (m *RemoteSecretPropagationManager) updateMultiClusterService(ctx context.Context, cd *kcmv1beta1.ClusterDeployment, oldMCS *kcmv1beta1.MultiClusterService) error {
+	newMCS := m.generateMultiClusterService(cd)
+
+	if labels.IstioVersion(newMCS.Labels) == labels.IstioVersion(oldMCS.Labels) {
+		return nil
+	}
+
+	oldMCS.Spec = newMCS.Spec
+	oldMCS.Labels = newMCS.Labels
+	if err := m.client.Update(ctx, oldMCS); err != nil {
+		return fmt.Errorf("failed to update MultiClusterService: %w", err)
+	}
+
+	m.sendUpdateEvent(cd)
+	return nil
+}
+
+func (m *RemoteSecretPropagationManager) getMultiClusterService(ctx context.Context, name, namespace string) (*kcmv1beta1.MultiClusterService, error) {
+	mcs := new(kcmv1beta1.MultiClusterService)
+	if err := m.client.Get(ctx, types.NamespacedName{
+		Name: MultiClusterServiceName(name, namespace),
+	}, mcs); err != nil {
+		if errors.IsNotFound(err) {
+			return nil, nil
+		}
+		return nil, err
+	}
+	return mcs, nil
 }
 
 func (m *RemoteSecretPropagationManager) createMultiClusterService(ctx context.Context, cd *kcmv1beta1.ClusterDeployment) error {
+	mcs := m.generateMultiClusterService(cd)
+	return client.IgnoreAlreadyExists(m.client.Create(ctx, mcs))
+}
+
+func (m *RemoteSecretPropagationManager) generateMultiClusterService(cd *kcmv1beta1.ClusterDeployment) *kcmv1beta1.MultiClusterService {
 	// One per-cluster MCS ships both discovery and CA material.
 	remoteIdentifier := "RemoteSecretData"
 	caIdentifier := "CASecretData"
@@ -108,20 +139,23 @@ func (m *RemoteSecretPropagationManager) createMultiClusterService(ctx context.C
 
 	mcs := &kcmv1beta1.MultiClusterService{
 		ObjectMeta: metav1.ObjectMeta{
-			Name: GetMultiClusterServiceNameHash(cd.Name, cd.Namespace),
+			Name: MultiClusterServiceName(cd.Name, cd.Namespace),
 			Labels: map[string]string{
-				utils.ManagedByLabel: utils.ManagedByValue,
-				"cluster-name":       cd.Name,
-				"cluster-namespace":  cd.Namespace,
+				labels.ClusterNameLabel:      cd.Name,
+				labels.ClusterNamespaceLabel: cd.Namespace,
+				labels.IstioVersionLabel:     istio.ReleaseVersion,
+				labels.ManagedByLabel:        labels.ManagedByIstioOperator,
 			},
 		},
 		Spec: kcmv1beta1.MultiClusterServiceSpec{
 			ClusterSelector: metav1.LabelSelector{
 				MatchLabels: map[string]string{
-					istio.IstioRoleLabel: "member",
+					labels.IstioRoleLabel: labels.IstioRoleLabelMemberValue,
 				},
 			},
-			DependsOn: []string{GetNamespaceMultiClusterServiceName()},
+			DependsOn: []string{
+				GetNamespaceMultiClusterServiceName(),
+			},
 			ServiceSpec: kcmv1beta1.ServiceSpec{
 				Services: []kcmv1beta1.Service{
 					{
@@ -165,23 +199,17 @@ func (m *RemoteSecretPropagationManager) createMultiClusterService(ctx context.C
 
 	if utils.IsInMesh(cd) {
 		// If cluster is in mesh, set selector to propagate only to clusters in same mesh
-		mcs.Spec.ClusterSelector.MatchLabels[utils.IstioMeshLabel] = cd.Labels[utils.IstioMeshLabel]
+		mcs.Spec.ClusterSelector.MatchLabels[labels.IstioMeshLabel] = cd.Labels[labels.IstioMeshLabel]
 	} else {
 		mcs.Spec.ClusterSelector.MatchExpressions = []metav1.LabelSelectorRequirement{
 			{
-				Key:      utils.IstioMeshLabel,
+				Key:      labels.IstioMeshLabel,
 				Operator: metav1.LabelSelectorOpDoesNotExist,
 			},
 		}
 	}
 
-	if err := m.client.Create(ctx, mcs); err != nil {
-		if errors.IsAlreadyExists(err) {
-			return nil
-		}
-		return err
-	}
-	return nil
+	return mcs
 }
 
 // tryDeleteDeprecatedPropagationMCS attempts to delete the MultiClusterService created by older versions of the operator for secret propagation,
@@ -201,13 +229,23 @@ func (m *RemoteSecretPropagationManager) tryDeleteDeprecatedPropagationMCS(ctx c
 	return m.client.Delete(ctx, mcs)
 }
 
+func (m *RemoteSecretPropagationManager) sendUpdateEvent(cd *kcmv1beta1.ClusterDeployment) {
+	record.Eventf(
+		cd,
+		utils.GetEventsAnnotations(cd),
+		"MultiClusterServiceUpdated",
+		"MultiClusterService '%s' for secret propagation is successfully updated",
+		MultiClusterServiceName(cd.Name, cd.Namespace),
+	)
+}
+
 func (m *RemoteSecretPropagationManager) sendCreationEvent(cd *kcmv1beta1.ClusterDeployment) {
 	record.Eventf(
 		cd,
 		utils.GetEventsAnnotations(cd),
 		"MultiClusterServiceCreated",
 		"MultiClusterService '%s' for secret propagation is successfully created",
-		GetMultiClusterServiceNameHash(cd.Name, cd.Namespace),
+		MultiClusterServiceName(cd.Name, cd.Namespace),
 	)
 }
 
@@ -218,21 +256,24 @@ func (m *RemoteSecretPropagationManager) sendDeletionEvent(req ctrl.Request) {
 		nil,
 		"MultiClusterServiceDeleted",
 		"MultiClusterService '%s' for secret propagation is successfully deleted",
-		GetMultiClusterServiceNameHash(req.Name, req.Namespace),
+		MultiClusterServiceName(req.Name, req.Namespace),
 	)
 }
 
 func getDeprecatedMultiClusterServiceName(clusterName, namespace string) string {
-	name := GetMultiClusterServiceName(clusterName, namespace)
+	name := multiClusterServiceKey(clusterName, namespace)
 	return hash.WithPrefix("remote-secret-propagation", name, hash.FnvHash)
 }
 
-func GetMultiClusterServiceName(clusterName, namespace string) string {
+// multiClusterServiceKey returns the canonical "namespace-name" key for the given cluster.
+func multiClusterServiceKey(clusterName, namespace string) string {
 	return fmt.Sprintf("%s-%s", namespace, clusterName)
 }
 
-func GetMultiClusterServiceNameHash(clusterName, namespace string) string {
-	name := GetMultiClusterServiceName(clusterName, namespace)
+// MultiClusterServiceName returns the unique hashed name for the MultiClusterService
+// managing secret propagation for the given cluster.
+func MultiClusterServiceName(clusterName, namespace string) string {
+	name := multiClusterServiceKey(clusterName, namespace)
 	return hash.WithPrefix("istio-secrets-propagation", name, hash.AdlerHash)
 }
 

--- a/istio-operator/internal/controller/istio/multicluster/remote_secret_propagation_manager_test.go
+++ b/istio-operator/internal/controller/istio/multicluster/remote_secret_propagation_manager_test.go
@@ -35,7 +35,7 @@ func TestTryCreate_CreatesMCSWhenNotExists(t *testing.T) {
 		t.Fatalf("MCS was not created: %v", err)
 	}
 
-	if got := mcs.Labels[labels.IstioVersionLabel]; got != "1.0.0" {
+	if got := mcs.Labels[labels.K0rdentIstioVersionLabel]; got != "1.0.0" {
 		t.Errorf("expected version label %q, got %q", "1.0.0", got)
 	}
 }
@@ -50,7 +50,7 @@ func TestTryCreate_UpdatesMCSWhenVersionChanges(t *testing.T) {
 		ObjectMeta: metav1.ObjectMeta{
 			Name: MultiClusterServiceName(cd.Name, cd.Namespace),
 			Labels: map[string]string{
-				labels.IstioVersionLabel: "1.0.0",
+				labels.K0rdentIstioVersionLabel: "1.0.0",
 			},
 		},
 	}
@@ -71,7 +71,7 @@ func TestTryCreate_UpdatesMCSWhenVersionChanges(t *testing.T) {
 		t.Fatalf("failed to get MCS: %v", err)
 	}
 
-	if got := mcs.Labels[labels.IstioVersionLabel]; got != "1.1.0" {
+	if got := mcs.Labels[labels.K0rdentIstioVersionLabel]; got != "1.1.0" {
 		t.Errorf("expected updated version label %q, got %q", "1.1.0", got)
 	}
 }
@@ -86,7 +86,7 @@ func TestTryCreate_SkipsUpdateWhenVersionUnchanged(t *testing.T) {
 			Name:            MultiClusterServiceName(cd.Name, cd.Namespace),
 			ResourceVersion: "999",
 			Labels: map[string]string{
-				labels.IstioVersionLabel: "1.0.0",
+				labels.K0rdentIstioVersionLabel: "1.0.0",
 			},
 		},
 	}
@@ -131,7 +131,7 @@ func TestTryCreate_SequentialVersionUpgrades(t *testing.T) {
 			t.Fatalf("failed to get MCS at version %s: %v", version, err)
 		}
 
-		if got := mcs.Labels[labels.IstioVersionLabel]; got != version {
+		if got := mcs.Labels[labels.K0rdentIstioVersionLabel]; got != version {
 			t.Errorf("version %s: expected label %q, got %q", version, version, got)
 		}
 	}

--- a/istio-operator/internal/controller/istio/multicluster/remote_secret_propagation_manager_test.go
+++ b/istio-operator/internal/controller/istio/multicluster/remote_secret_propagation_manager_test.go
@@ -1,0 +1,180 @@
+package multicluster
+
+import (
+	"context"
+	"testing"
+
+	kcmv1beta1 "github.com/K0rdent/kcm/api/v1beta1"
+	"github.com/k0rdent/istio/istio-operator/internal/controller/istio"
+	"github.com/k0rdent/istio/istio-operator/internal/controller/record"
+	"github.com/k0rdent/istio/istio-operator/internal/labels"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/types"
+	k8sscheme "k8s.io/client-go/kubernetes/scheme"
+	"k8s.io/client-go/tools/events"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
+)
+
+func TestTryCreate_CreatesMCSWhenNotExists(t *testing.T) {
+	setupTest(t, "1.0.0")
+
+	cd := newClusterDeployment()
+	c := newFakeClient(t)
+	manager := New(c)
+
+	if err := manager.TryCreate(context.Background(), cd); err != nil {
+		t.Fatalf("TryCreate returned error: %v", err)
+	}
+
+	mcs := &kcmv1beta1.MultiClusterService{}
+	if err := c.Get(context.Background(), types.NamespacedName{
+		Name: MultiClusterServiceName(cd.Name, cd.Namespace),
+	}, mcs); err != nil {
+		t.Fatalf("MCS was not created: %v", err)
+	}
+
+	if got := mcs.Labels[labels.IstioVersionLabel]; got != "1.0.0" {
+		t.Errorf("expected version label %q, got %q", "1.0.0", got)
+	}
+}
+
+func TestTryCreate_UpdatesMCSWhenVersionChanges(t *testing.T) {
+	setupTest(t, "1.0.0")
+
+	cd := newClusterDeployment()
+
+	// Pre-create MCS with old version label.
+	existingMCS := &kcmv1beta1.MultiClusterService{
+		ObjectMeta: metav1.ObjectMeta{
+			Name: MultiClusterServiceName(cd.Name, cd.Namespace),
+			Labels: map[string]string{
+				labels.IstioVersionLabel: "1.0.0",
+			},
+		},
+	}
+	c := newFakeClient(t, existingMCS)
+	manager := New(c)
+
+	// Simulate a version upgrade.
+	istio.ReleaseVersion = "1.1.0"
+
+	if err := manager.TryCreate(context.Background(), cd); err != nil {
+		t.Fatalf("TryCreate returned error: %v", err)
+	}
+
+	mcs := &kcmv1beta1.MultiClusterService{}
+	if err := c.Get(context.Background(), types.NamespacedName{
+		Name: MultiClusterServiceName(cd.Name, cd.Namespace),
+	}, mcs); err != nil {
+		t.Fatalf("failed to get MCS: %v", err)
+	}
+
+	if got := mcs.Labels[labels.IstioVersionLabel]; got != "1.1.0" {
+		t.Errorf("expected updated version label %q, got %q", "1.1.0", got)
+	}
+}
+
+func TestTryCreate_SkipsUpdateWhenVersionUnchanged(t *testing.T) {
+	setupTest(t, "1.0.0")
+
+	cd := newClusterDeployment()
+
+	existingMCS := &kcmv1beta1.MultiClusterService{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:            MultiClusterServiceName(cd.Name, cd.Namespace),
+			ResourceVersion: "999",
+			Labels: map[string]string{
+				labels.IstioVersionLabel: "1.0.0",
+			},
+		},
+	}
+	c := newFakeClient(t, existingMCS)
+	manager := New(c)
+
+	if err := manager.TryCreate(context.Background(), cd); err != nil {
+		t.Fatalf("TryCreate returned error: %v", err)
+	}
+
+	mcs := &kcmv1beta1.MultiClusterService{}
+	if err := c.Get(context.Background(), types.NamespacedName{
+		Name: MultiClusterServiceName(cd.Name, cd.Namespace),
+	}, mcs); err != nil {
+		t.Fatalf("failed to get MCS: %v", err)
+	}
+
+	// ResourceVersion must not change — no update was issued.
+	if mcs.ResourceVersion != "999" {
+		t.Errorf("expected ResourceVersion %q (no update), got %q", "999", mcs.ResourceVersion)
+	}
+}
+
+func TestTryCreate_SequentialVersionUpgrades(t *testing.T) {
+	versions := []string{"1.0.0", "1.1.0", "2.0.0", "2.1.0"}
+
+	cd := newClusterDeployment()
+	c := newFakeClient(t)
+	manager := New(c)
+
+	for _, version := range versions {
+		setupTest(t, version)
+
+		if err := manager.TryCreate(context.Background(), cd); err != nil {
+			t.Fatalf("TryCreate returned error at version %s: %v", version, err)
+		}
+
+		mcs := &kcmv1beta1.MultiClusterService{}
+		if err := c.Get(context.Background(), types.NamespacedName{
+			Name: MultiClusterServiceName(cd.Name, cd.Namespace),
+		}, mcs); err != nil {
+			t.Fatalf("failed to get MCS at version %s: %v", version, err)
+		}
+
+		if got := mcs.Labels[labels.IstioVersionLabel]; got != version {
+			t.Errorf("version %s: expected label %q, got %q", version, version, got)
+		}
+	}
+}
+
+// setupTest initialises shared global state required by the manager under test.
+func setupTest(t *testing.T, releaseVersion string) {
+	t.Helper()
+	record.DefaultRecorder = events.NewFakeRecorder(16)
+	istio.IstioSystemNamespace = "istio-system"
+	istio.IstioReleaseName = "test-istio"
+	istio.ReleaseVersion = releaseVersion
+}
+
+func newClusterDeployment() *kcmv1beta1.ClusterDeployment {
+	return &kcmv1beta1.ClusterDeployment{
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      "cluster-a",
+			Namespace: "default",
+			Labels: map[string]string{
+				labels.IstioRoleLabel: labels.IstioRoleLabelMemberValue,
+			},
+		},
+		Spec: kcmv1beta1.ClusterDeploymentSpec{
+			Template:   "test-template",
+			Credential: "test-credential",
+		},
+	}
+}
+
+func newFakeClient(t *testing.T, objects ...client.Object) client.Client {
+	t.Helper()
+
+	s := runtime.NewScheme()
+	if err := k8sscheme.AddToScheme(s); err != nil {
+		t.Fatalf("failed to add core scheme: %v", err)
+	}
+	if err := kcmv1beta1.AddToScheme(s); err != nil {
+		t.Fatalf("failed to add kcm scheme: %v", err)
+	}
+
+	return fake.NewClientBuilder().
+		WithScheme(s).
+		WithObjects(objects...).
+		Build()
+}

--- a/istio-operator/internal/controller/istio/remote-secret/fake_remote_secret_manager.go
+++ b/istio-operator/internal/controller/istio/remote-secret/fake_remote_secret_manager.go
@@ -14,12 +14,12 @@ type FakeRemoteSecretCreator struct{}
 
 func NewFakeManager(c client.Client) *RemoteSecretManager {
 	return &RemoteSecretManager{
-		client:                    c,
-		IIstioRemoteSecretCreator: NewFakeRemoteSecretCreator(),
+		client:  c,
+		creator: NewFakeRemoteSecretCreator(),
 	}
 }
 
-func NewFakeRemoteSecretCreator() IIstioRemoteSecretCreator {
+func NewFakeRemoteSecretCreator() RemoteSecretCreator {
 	return &FakeRemoteSecretCreator{}
 }
 

--- a/istio-operator/internal/controller/istio/remote-secret/remote_secret.go
+++ b/istio-operator/internal/controller/istio/remote-secret/remote_secret.go
@@ -262,7 +262,7 @@ func createRemoteServiceAccountSecret(kubeconfig *api.Config, clusterName, secNa
 				clusterNameAnnotationKey: clusterName,
 			},
 			Labels: map[string]string{
-				labels.IstioVersionLabel:         istio.ReleaseVersion,
+				labels.K0rdentIstioVersionLabel:  istio.ReleaseVersion,
 				labels.ManagedByLabel:            labels.ManagedByIstioOperator,
 				mcluster.MultiClusterSecretLabel: "true",
 			},
@@ -467,8 +467,8 @@ func getOrCreateServiceAccountSecret(
 			Name:      secretName,
 			Namespace: opt.Namespace,
 			Labels: map[string]string{
-				labels.IstioVersionLabel: istio.ReleaseVersion,
-				labels.ManagedByLabel:    labels.ManagedByIstioOperator,
+				labels.K0rdentIstioVersionLabel: istio.ReleaseVersion,
+				labels.ManagedByLabel:           labels.ManagedByIstioOperator,
 			},
 			Annotations: map[string]string{v1.ServiceAccountNameKey: serviceAccount.Name},
 		},

--- a/istio-operator/internal/controller/istio/remote-secret/remote_secret.go
+++ b/istio-operator/internal/controller/istio/remote-secret/remote_secret.go
@@ -24,8 +24,10 @@ import (
 	"time"
 
 	"github.com/cenkalti/backoff/v4"
+	"github.com/k0rdent/istio/istio-operator/internal/controller/istio"
 	"github.com/k0rdent/istio/istio-operator/internal/hash"
 	"github.com/k0rdent/istio/istio-operator/internal/k8s"
+	"github.com/k0rdent/istio/istio-operator/internal/labels"
 	"github.com/spf13/pflag"
 	"istio.io/istio/pkg/config/constants"
 	mcluster "istio.io/istio/pkg/kube/multicluster"
@@ -260,6 +262,8 @@ func createRemoteServiceAccountSecret(kubeconfig *api.Config, clusterName, secNa
 				clusterNameAnnotationKey: clusterName,
 			},
 			Labels: map[string]string{
+				labels.IstioVersionLabel:         istio.ReleaseVersion,
+				labels.ManagedByLabel:            labels.ManagedByIstioOperator,
 				mcluster.MultiClusterSecretLabel: "true",
 			},
 		},
@@ -460,8 +464,12 @@ func getOrCreateServiceAccountSecret(
 
 	secret := &v1.Secret{
 		ObjectMeta: metav1.ObjectMeta{
-			Name:        secretName,
-			Namespace:   opt.Namespace,
+			Name:      secretName,
+			Namespace: opt.Namespace,
+			Labels: map[string]string{
+				labels.IstioVersionLabel: istio.ReleaseVersion,
+				labels.ManagedByLabel:    labels.ManagedByIstioOperator,
+			},
 			Annotations: map[string]string{v1.ServiceAccountNameKey: serviceAccount.Name},
 		},
 		Type: v1.SecretTypeOpaque,

--- a/istio-operator/internal/controller/istio/remote-secret/remote_secret_manager.go
+++ b/istio-operator/internal/controller/istio/remote-secret/remote_secret_manager.go
@@ -26,18 +26,18 @@ type CreateOptions struct {
 }
 
 type RemoteSecretManager struct {
-	client client.Client
-	IIstioRemoteSecretCreator
+	client  client.Client
+	creator RemoteSecretCreator
 }
 
 func New(c client.Client) *RemoteSecretManager {
 	return &RemoteSecretManager{
-		client:                    c,
-		IIstioRemoteSecretCreator: NewIstioRemoteSecret(),
+		client:  c,
+		creator: newDefaultRemoteSecretCreator(),
 	}
 }
 
-// Function tries to delete the remote secret
+// TryDelete deletes the remote secret for the given request.
 func (rs *RemoteSecretManager) TryDelete(ctx context.Context, request ctrl.Request) error {
 	log := log.FromContext(ctx)
 	log.Info("Trying to delete remote secret")
@@ -64,7 +64,7 @@ func (rs *RemoteSecretManager) TryDelete(ctx context.Context, request ctrl.Reque
 	return nil
 }
 
-// Function handles the creation of a remote secret
+// TryCreate creates a remote secret for the given cluster deployment.
 func (rs *RemoteSecretManager) TryCreate(ctx context.Context, clusterDeployment *kcmv1beta1.ClusterDeployment, opt CreateOptions) error {
 	log := log.FromContext(ctx)
 	log.Info("Trying to create remote secret")
@@ -81,7 +81,7 @@ func (rs *RemoteSecretManager) TryCreate(ctx context.Context, clusterDeployment 
 	if !opt.AllowOverwrite {
 		exists, err := rs.remoteSecretExists(ctx, clusterDeployment)
 		if err != nil {
-			return fmt.Errorf("failed to check remote secret: %v", err)
+			return fmt.Errorf("failed to check remote secret: %w", err)
 		}
 
 		if exists {
@@ -97,12 +97,12 @@ func (rs *RemoteSecretManager) TryCreate(ctx context.Context, clusterDeployment 
 	if createdInKCMRegion {
 		regionClusterName, err := k8s.GetKcmRegionClusterNameRelatedToClusterDeployment(ctx, rs.client, clusterDeployment)
 		if err != nil {
-			return fmt.Errorf("failed to get cluster region: %v", err)
+			return fmt.Errorf("failed to get cluster region: %w", err)
 		}
 
 		regionKubeconfig, err := k8s.GetKubeconfigByRegionName(ctx, rs.client, regionClusterName)
 		if err != nil {
-			return fmt.Errorf("failed to get kubeconfig by region name: %v", err)
+			return fmt.Errorf("failed to get kubeconfig by region name: %w", err)
 		}
 
 		if regionKubeconfig == nil {
@@ -111,7 +111,7 @@ func (rs *RemoteSecretManager) TryCreate(ctx context.Context, clusterDeployment 
 
 		regionClient, err := k8s.NewKubeClientFromKubeconfig(regionKubeconfig)
 		if err != nil {
-			return fmt.Errorf("failed to create kube client from region kubeconfig: %v", err)
+			return fmt.Errorf("failed to create kube client from region kubeconfig: %w", err)
 		}
 
 		regionKubeClient = regionClient.Client
@@ -119,22 +119,22 @@ func (rs *RemoteSecretManager) TryCreate(ctx context.Context, clusterDeployment 
 
 	kubeconfigSecretName, err := k8s.GetKubeconfigSecretName(ctx, rs.client, clusterDeployment)
 	if err != nil {
-		return fmt.Errorf("failed to get kubeconfig secret name: %v", err)
+		return fmt.Errorf("failed to get kubeconfig secret name: %w", err)
 	}
 
 	kubeconfig, err := k8s.GetKubeconfigFromSecretInNamespace(ctx, regionKubeClient, kubeconfigSecretName, clusterDeployment.Namespace)
 	if err != nil {
-		return fmt.Errorf("failed to get kubeconfig from secret: %v", err)
+		return fmt.Errorf("failed to get kubeconfig from secret: %w", err)
 	}
 
-	remoteSecret, err := rs.GetRemoteSecret(ctx, kubeconfig, clusterDeployment, opt)
+	remoteSecret, err := rs.creator.GetRemoteSecret(ctx, kubeconfig, clusterDeployment, opt)
 	if err != nil {
-		return fmt.Errorf("failed to get remote secret: %v", err)
+		return fmt.Errorf("failed to get remote secret: %w", err)
 	}
 
 	if err := rs.createSecretResource(ctx, remoteSecret); err != nil {
 		log.Error(err, "failed to create remote secret")
-		return fmt.Errorf("failed to create remote secret: %v", err)
+		return fmt.Errorf("failed to create remote secret: %w", err)
 	}
 
 	rs.sendCreationEvent(clusterDeployment)
@@ -148,9 +148,9 @@ func (rs *RemoteSecretManager) remoteSecretExists(ctx context.Context, cd *kcmv1
 	return utils.IsResourceExists(ctx, rs.client, secret, secretName, istio.IstioSystemNamespace)
 }
 
-// Function creates the remote secret resource in k8s
+// createSecretResource deletes any existing secret and recreates it.
 func (rs *RemoteSecretManager) createSecretResource(ctx context.Context, secret *corev1.Secret) error {
-	if err := rs.client.Delete(ctx, secret); err != nil && !errors.IsNotFound(err) {
+	if err := client.IgnoreNotFound(rs.client.Delete(ctx, secret)); err != nil {
 		return err
 	}
 
@@ -203,18 +203,19 @@ func getDeprecatedRemoteSecretName(clusterName, namespace string) string {
 	return hash.WithPrefix(remoteSecretPrefix, name, hash.FnvHash)
 }
 
-type IstioRemoteSecretCreator struct{}
-
-type IIstioRemoteSecretCreator interface {
+// RemoteSecretCreator creates a remote secret from a kubeconfig and cluster deployment.
+type RemoteSecretCreator interface {
 	GetRemoteSecret(context.Context, []byte, *kcmv1beta1.ClusterDeployment, CreateOptions) (*corev1.Secret, error)
 }
 
-func NewIstioRemoteSecret() IIstioRemoteSecretCreator {
-	return &IstioRemoteSecretCreator{}
+type defaultRemoteSecretCreator struct{}
+
+func newDefaultRemoteSecretCreator() RemoteSecretCreator {
+	return &defaultRemoteSecretCreator{}
 }
 
-// Function creates a remote secret for Istio using the provided kubeconfig
-func (rs *IstioRemoteSecretCreator) GetRemoteSecret(ctx context.Context, kubeconfig []byte, clusterDeployment *kcmv1beta1.ClusterDeployment, opt CreateOptions) (*corev1.Secret, error) {
+// GetRemoteSecret creates a remote secret for Istio using the provided kubeconfig.
+func (rs *defaultRemoteSecretCreator) GetRemoteSecret(ctx context.Context, kubeconfig []byte, clusterDeployment *kcmv1beta1.ClusterDeployment, opt CreateOptions) (*corev1.Secret, error) {
 	log := log.FromContext(ctx)
 
 	kubeClient, err := k8s.NewKubeClientFromKubeconfig(kubeconfig)

--- a/istio-operator/internal/controller/utils/utils.go
+++ b/istio-operator/internal/controller/utils/utils.go
@@ -8,6 +8,7 @@ import (
 
 	kcmv1beta1 "github.com/K0rdent/kcm/api/v1beta1"
 	"github.com/k0rdent/istio/istio-operator/internal/controller/record"
+	"github.com/k0rdent/istio/istio-operator/internal/labels"
 	"k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime"
@@ -15,10 +16,6 @@ import (
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/log"
 )
-
-const IstioMeshLabel = "k0rdent.mirantis.com/istio-mesh"
-const ManagedByLabel = "app.kubernetes.io/managed-by"
-const ManagedByValue = "istio-operator"
 
 func GetEventsAnnotations(obj runtime.Object) map[string]string {
 	var generation string
@@ -46,7 +43,7 @@ func GetClusterDeploymentStub(name, namespace string) *kcmv1beta1.ClusterDeploym
 			Namespace: namespace,
 		},
 		TypeMeta: metav1.TypeMeta{
-			APIVersion: "k0rdent.mirantis.com/v1beta1",
+			APIVersion: kcmv1beta1.GroupVersion.String(),
 			Kind:       kcmv1beta1.ClusterDeploymentKind,
 		},
 	}
@@ -123,8 +120,7 @@ func IsResourceExists(ctx context.Context, client client.Client, obj client.Obje
 }
 
 func IsInMesh(cd *kcmv1beta1.ClusterDeployment) bool {
-	_, ok := cd.Labels[IstioMeshLabel]
-	return ok
+	return labels.HasIstioMeshLabel(cd.Labels)
 }
 
 // MustPropagationServiceValuesYAML builds Helm values for propagation.yaml.
@@ -169,6 +165,6 @@ func IsClusterDeploymentReady(cd *kcmv1beta1.ClusterDeployment) bool {
 }
 
 func IsResourceCreatedByOperator(obj metav1.Object) bool {
-	v, ok := obj.GetLabels()[ManagedByLabel]
-	return ok && v == ManagedByValue
+	v, ok := obj.GetLabels()[labels.ManagedByLabel]
+	return ok && v == labels.ManagedByIstioOperator
 }

--- a/istio-operator/internal/k8s/client.go
+++ b/istio-operator/internal/k8s/client.go
@@ -52,7 +52,7 @@ func NewKubeClientFromKubeconfig(kubeconfig []byte) (*KubeClient, error) {
 func GetKubeconfigFromClusterDeployment(ctx context.Context, client client.Client, cd *kcmv1beta1.ClusterDeployment) ([]byte, error) {
 	kubeconfigSecretName, err := GetKubeconfigSecretName(ctx, client, cd)
 	if err != nil {
-		return nil, fmt.Errorf("failed to get kubeconfig secret name: %v", err)
+		return nil, fmt.Errorf("failed to get kubeconfig secret name: %w", err)
 	}
 
 	return GetKubeconfigFromSecretInNamespace(ctx, client, kubeconfigSecretName, cd.Namespace)
@@ -65,7 +65,7 @@ func GetKubeconfigFromSecret(ctx context.Context, client client.Client, secretNa
 func GetKubeconfigFromSecretInNamespace(ctx context.Context, client client.Client, secretName, namespace string) ([]byte, error) {
 	secret, err := GetSecret(ctx, client, secretName, namespace)
 	if err != nil {
-		return nil, fmt.Errorf("failed to get secret: %v", err)
+		return nil, fmt.Errorf("failed to get secret: %w", err)
 	}
 
 	kubeconfig := GetSecretValue(secret)
@@ -79,7 +79,7 @@ func GetKubeconfigFromSecretInNamespace(ctx context.Context, client client.Clien
 func NewKubeClientFromSecret(ctx context.Context, client client.Client, secretName, namespace string) (*KubeClient, error) {
 	secret, err := GetSecret(ctx, client, secretName, namespace)
 	if err != nil {
-		return nil, fmt.Errorf("failed to get secret: %v", err)
+		return nil, fmt.Errorf("failed to get secret: %w", err)
 	}
 
 	kubeconfig := GetSecretValue(secret)
@@ -89,7 +89,7 @@ func NewKubeClientFromSecret(ctx context.Context, client client.Client, secretNa
 
 	kubeClient, err := NewKubeClientFromKubeconfig(kubeconfig)
 	if err != nil {
-		return nil, fmt.Errorf("failed to create new client from kubeconfig: %v", err)
+		return nil, fmt.Errorf("failed to create new client from kubeconfig: %w", err)
 	}
 
 	return kubeClient, nil

--- a/istio-operator/internal/k8s/region.go
+++ b/istio-operator/internal/k8s/region.go
@@ -45,7 +45,7 @@ func GetKubeconfigByRegionName(ctx context.Context, client client.Client, region
 
 	region := new(kcmv1beta1.Region)
 	if err := client.Get(ctx, types.NamespacedName{Name: regionName}, region); err != nil {
-		return nil, fmt.Errorf("failed to get Region %s: %v", regionName, err)
+		return nil, fmt.Errorf("failed to get Region %s: %w", regionName, err)
 	}
 
 	if region.Spec.ClusterDeployment != nil {
@@ -54,12 +54,12 @@ func GetKubeconfigByRegionName(ctx context.Context, client client.Client, region
 			Name:      region.Spec.ClusterDeployment.Name,
 			Namespace: region.Spec.ClusterDeployment.Namespace,
 		}, cd); err != nil {
-			return nil, fmt.Errorf("failed to get ClusterDeployment %s: %v", region.Spec.ClusterDeployment.Name, err)
+			return nil, fmt.Errorf("failed to get ClusterDeployment %s: %w", region.Spec.ClusterDeployment.Name, err)
 		}
 
 		kubeconfig, err := GetKubeconfigFromClusterDeployment(ctx, client, cd)
 		if err != nil {
-			return nil, fmt.Errorf("failed to get kubeconfig from ClusterDeployment: %v", err)
+			return nil, fmt.Errorf("failed to get kubeconfig from ClusterDeployment: %w", err)
 		}
 		return kubeconfig, nil
 	}

--- a/istio-operator/internal/labels/labels.go
+++ b/istio-operator/internal/labels/labels.go
@@ -3,18 +3,18 @@ package labels
 const (
 	// IstioMeshLabel is used to label all resources that belong to the same mesh, so that they can be easily selected.
 	IstioMeshLabel = "k0rdent.mirantis.com/istio-mesh"
-	// IstioVersionLabel is used to label all resources with the version of Istio they are associated with.
-	IstioVersionLabel = "k0rdent.mirantis.com/istio-release-version"
+	// K0rdentIstioVersionLabel is used to label all resources with the k0rdent-Istio release version they are associated with.
+	K0rdentIstioVersionLabel = "k0rdent.mirantis.com/istio-release-version"
 
 	// IstioRoleLabel is used on ClusterDeployment objects to indicate that the cluster is using Istio.
 	IstioRoleLabel = "k0rdent.mirantis.com/istio-role"
 	// IstioRoleLabelMemberValue is the value of the `k0rdent.mirantis.com/istio-role` label for clusters that are part of an Istio mesh.
 	IstioRoleLabelMemberValue = "member"
-	// IstioRoleLabelChildValue is the value of the `k0rdent.mirantis.com/istio-role` label for clusters that are part of an Istio mesh, but should be ignored by the operator.
-	// This is deprecated but still supported for backward compatibility with existing clusters. New clusters that should be ignored by the operator should use `member` instead.
+	// IstioRoleLabelChildValue is a deprecated legacy value of the `k0rdent.mirantis.com/istio-role` label for clusters that are part of an Istio mesh.
+	// It is still supported for backward compatibility with existing clusters; new clusters should use `member`.
 	IstioRoleLabelChildValue = "child"
 
-	// ManagedByLabel are used to label all resources managed by the istio-operator, so that they can be easily selected.
+	// ManagedByLabel is used to label all resources managed by the istio-operator, so that they can be easily selected.
 	ManagedByLabel = "app.kubernetes.io/managed-by"
 	// ManagedByIstioOperator is the value of the `app.kubernetes.io/managed-by` label for all resources managed by the istio-operator.
 	ManagedByIstioOperator = "istio-operator"
@@ -37,5 +37,5 @@ func HasIstioRoleLabel(labels map[string]string) bool {
 
 // IstioVersion returns the value of the `k0rdent.mirantis.com/istio-release-version` label, or an empty string if the label is not present.
 func IstioVersion(labels map[string]string) string {
-	return labels[IstioVersionLabel]
+	return labels[K0rdentIstioVersionLabel]
 }

--- a/istio-operator/internal/labels/labels.go
+++ b/istio-operator/internal/labels/labels.go
@@ -1,0 +1,41 @@
+package labels
+
+const (
+	// IstioMeshLabel is used to label all resources that belong to the same mesh, so that they can be easily selected.
+	IstioMeshLabel = "k0rdent.mirantis.com/istio-mesh"
+	// IstioVersionLabel is used to label all resources with the version of Istio they are associated with.
+	IstioVersionLabel = "k0rdent.mirantis.com/istio-release-version"
+
+	// IstioRoleLabel is used on ClusterDeployment objects to indicate that the cluster is using Istio.
+	IstioRoleLabel = "k0rdent.mirantis.com/istio-role"
+	// IstioRoleLabelMemberValue is the value of the `k0rdent.mirantis.com/istio-role` label for clusters that are part of an Istio mesh.
+	IstioRoleLabelMemberValue = "member"
+	// IstioRoleLabelChildValue is the value of the `k0rdent.mirantis.com/istio-role` label for clusters that are part of an Istio mesh, but should be ignored by the operator.
+	// This is deprecated but still supported for backward compatibility with existing clusters. New clusters that should be ignored by the operator should use `member` instead.
+	IstioRoleLabelChildValue = "child"
+
+	// ManagedByLabel are used to label all resources managed by the istio-operator, so that they can be easily selected.
+	ManagedByLabel = "app.kubernetes.io/managed-by"
+	// ManagedByIstioOperator is the value of the `app.kubernetes.io/managed-by` label for all resources managed by the istio-operator.
+	ManagedByIstioOperator = "istio-operator"
+
+	// ClusterNameLabel is used to label resources with the name of the cluster they belong to.
+	ClusterNameLabel = "cluster-name"
+	// ClusterNamespaceLabel is used to label resources with the namespace of the cluster they belong to.
+	ClusterNamespaceLabel = "cluster-namespace"
+)
+
+func HasIstioMeshLabel(labels map[string]string) bool {
+	_, ok := labels[IstioMeshLabel]
+	return ok
+}
+
+func HasIstioRoleLabel(labels map[string]string) bool {
+	_, ok := labels[IstioRoleLabel]
+	return ok
+}
+
+// IstioVersion returns the value of the `k0rdent.mirantis.com/istio-release-version` label, or an empty string if the label is not present.
+func IstioVersion(labels map[string]string) string {
+	return labels[IstioVersionLabel]
+}

--- a/istio-operator/internal/secret-rotation/istio_secret_rotation.go
+++ b/istio-operator/internal/secret-rotation/istio_secret_rotation.go
@@ -6,9 +6,9 @@ import (
 	"time"
 
 	kcmv1beta1 "github.com/K0rdent/kcm/api/v1beta1"
-	"github.com/k0rdent/istio/istio-operator/internal/controller/istio"
 	remotesecret "github.com/k0rdent/istio/istio-operator/internal/controller/istio/remote-secret"
 	"github.com/k0rdent/istio/istio-operator/internal/k8s"
+	label "github.com/k0rdent/istio/istio-operator/internal/labels"
 	"k8s.io/apimachinery/pkg/labels"
 	"k8s.io/apimachinery/pkg/selection"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -97,7 +97,7 @@ func (m *Manager) rotateSecrets(ctx context.Context) {
 func (m *Manager) getIstioClusters(ctx context.Context) ([]kcmv1beta1.ClusterDeployment, error) {
 	clustersList := kcmv1beta1.ClusterDeploymentList{}
 
-	requirement, err := labels.NewRequirement(istio.IstioRoleLabel, selection.Exists, nil)
+	requirement, err := labels.NewRequirement(label.IstioRoleLabel, selection.Exists, nil)
 	if err != nil {
 		return nil, fmt.Errorf("failed to create label requirement: %w", err)
 	}


### PR DESCRIPTION
Previously, MCS resources created by the operator were not updated when the Istio version changed. This prevented spec changes from being applied during operator upgrades. Now the operator detects when the Istio release version label changes and applies the MCS spec update accordingly.

Closes: #55 